### PR TITLE
chore: move rspec-rails to development/test Gemfile group

### DIFF
--- a/street-comics-api/Gemfile
+++ b/street-comics-api/Gemfile
@@ -28,6 +28,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem "rspec-rails", "~> 5.0"
 end
 
 group :development do
@@ -41,5 +42,3 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "faraday", "~> 1.5"
 gem "faraday_middleware", "~> 1.1"
-
-gem "rspec-rails", "~> 5.0"


### PR DESCRIPTION
So that we ensure it doesn't get loaded in production