### PR TITLE
chore: add rspec-rails

### DIFF
--- a/street-comics-api/Gemfile
+++ b/street-comics-api/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem "rspec-rails", "~> 5.0"
+  gem "webmock", "~> 3.13"
 end
 
 group :development do

--- a/street-comics-api/Gemfile.lock
+++ b/street-comics-api/Gemfile.lock
@@ -60,11 +60,15 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     bootsnap (1.7.6)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
     concurrent-ruby (1.1.9)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
@@ -90,6 +94,7 @@ GEM
     ffi (1.15.3)
     globalid (0.5.1)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     listen (3.6.0)
@@ -109,6 +114,7 @@ GEM
     nio4r (2.5.7)
     nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
+    public_suffix (4.0.6)
     puma (5.4.0)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -145,6 +151,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rexml (3.2.5)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -175,6 +182,10 @@ GEM
     thor (1.1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    webmock (3.13.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -195,6 +206,7 @@ DEPENDENCIES
   spring
   sqlite3 (~> 1.4)
   tzinfo-data
+  webmock (~> 3.13)
 
 RUBY VERSION
    ruby 2.7.2p137


### PR DESCRIPTION
Added with:

```sh
docker-compose run --rm street-comics-api bundle add webmock
```

Will be used for some upcoming request specs so we can mock external API requests and keep the specs execution predictable.