### PR TITLE
feat(API): add get /api/v1/comics endpoint

### DIFF
--- a/street-comics-api/app/api/comics_api/v1/adapters/marvel/request_adapter.rb
+++ b/street-comics-api/app/api/comics_api/v1/adapters/marvel/request_adapter.rb
@@ -1,0 +1,16 @@
+module ComicsApi
+  module V1
+    module Adapters
+      module Marvel
+        class RequestAdapter
+
+          def initialize(args = nil) end
+
+          def comics(params)
+            params
+          end
+        end
+      end
+    end
+  end
+end

--- a/street-comics-api/app/api/comics_api/v1/adapters/marvel/response_adapter.rb
+++ b/street-comics-api/app/api/comics_api/v1/adapters/marvel/response_adapter.rb
@@ -1,0 +1,16 @@
+module ComicsApi
+  module V1
+    module Adapters
+      module Marvel
+        class ResponseAdapter
+          
+          def initialize(args = nil) end
+
+          def comics(response)
+            response
+          end
+        end
+      end
+    end
+  end
+end

--- a/street-comics-api/app/api/comics_api/v1/client.rb
+++ b/street-comics-api/app/api/comics_api/v1/client.rb
@@ -1,0 +1,57 @@
+module ComicsApi
+  module V1
+    class Client
+
+      attr_reader :client
+      attr_reader :request_adapter
+      attr_reader :response_adapter
+
+      def initialize(provider)
+        @client = find_client(provider)
+        @request_adapter = find_request_adapter(provider)
+        @response_adapter = find_response_adapter(provider)
+      end
+
+      def comics(params)
+        client_params = request_adapter.comics(params)
+        response = client.comics(client_params)
+        response_adapter.comics(response)
+      end
+
+      private
+
+      def find_client(provider)
+        find_service(provider, :client)
+      end
+
+      def find_request_adapter(provider)
+        find_service(provider, :request_adapter)
+      end
+
+      def find_response_adapter(provider)
+        find_service(provider, :response_adapter)
+      end
+
+      def find_service(provider, service, args = nil)
+        clazz = find_service_class(provider, service)
+        clazz.new(args)
+      end
+
+      def find_service_class(provider, service)
+        mapping
+          .fetch(provider.to_sym) { raise('invalid provider') }
+          .fetch(service.to_sym) { raise('invalid service') }
+      end
+
+      def mapping
+        {
+          marvel: {
+            client: MarvelApi::V1::Client,
+            request_adapter: Adapters::Marvel::RequestAdapter,
+            response_adapter: Adapters::Marvel::ResponseAdapter,
+          }
+        }
+      end
+    end
+  end
+end

--- a/street-comics-api/app/api/marvel_api/v1/client.rb
+++ b/street-comics-api/app/api/marvel_api/v1/client.rb
@@ -1,0 +1,45 @@
+module MarvelApi
+  module V1
+    class Client
+
+      def initialize(args = nil) end
+
+      def comics(params)
+        client.get('comics', params)
+      end
+
+      private
+
+      def client
+        @_client ||= Faraday.new(base_url, { params: default_params }) do |client|
+          client.request :json
+          client.response :json
+        end
+      end
+
+      def base_url
+        'https://gateway.marvel.com:443/v1/public'
+      end
+
+      def default_params
+        timestamp = Time.now.getutc.to_i.to_s
+        hash = Digest::MD5.hexdigest(timestamp + private_api_key + public_api_key)
+
+        {
+          ts: timestamp,
+          apikey: public_api_key,
+          hash: hash,
+        }
+      end
+
+      def public_api_key
+        'public_api_key'
+      end
+
+      def private_api_key
+        'private_api_key'
+      end
+    end
+  end
+end
+

--- a/street-comics-api/app/controllers/api/v1/comics_controller.rb
+++ b/street-comics-api/app/controllers/api/v1/comics_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module V1
+    class ComicsController < ApplicationController
+
+      def index
+        default_params = {
+          offset: 0,
+          limit: 15,
+        }
+
+        response = client.comics(params.with_defaults(default_params))
+
+        render json: response, status: 200
+      end
+
+      private
+
+      def client
+        provider = params.fetch(:provider)
+        ComicsApi::V1::Client.new(provider)
+      end
+    end
+
+  end
+end

--- a/street-comics-api/config/routes.rb
+++ b/street-comics-api/config/routes.rb
@@ -1,3 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  namespace :api do
+    namespace :v1 do
+      get '/comics', to: 'comics#index'
+    end
+  end
 end

--- a/street-comics-api/spec/requests/comics_get_spec.rb
+++ b/street-comics-api/spec/requests/comics_get_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe "Comics GET request" do
+
+  it 'accepts "marvel" as a provider' do
+    stub_comics_get_with
+
+    get '/api/v1/comics?provider=marvel'
+
+    expect(response.status).to eq(200)
+  end
+
+  it 'accepts an offset and limit via query params' do
+    stub_comics_get_with(
+      {
+        query_params: { "offset": "15", "limit": "30" },
+      })
+
+    get '/api/v1/comics?provider=marvel&offset=15&limit=30'
+
+    expect(response.status).to eq(200)
+  end
+
+  it 'has a default offset and limit' do
+    stub_comics_get_with(
+      {
+        query_params: { "offset": "0", "limit": "15" },
+      })
+
+    get '/api/v1/comics?provider=marvel'
+
+    expect(response.status).to eq(200)
+  end
+
+  it 'forwards the marvel response' do
+    stub_message = { "message" => "stub" }
+
+    stub_comics_get_with(
+      {
+        body_response: stub_message
+      })
+
+    get '/api/v1/comics?provider=marvel'
+
+    expect(json_response_body).to eq(stub_message)
+  end
+end
+
+def stub_comics_get_with(query_params: {}, status_code: 200, body_response: nil)
+  stub_request(:get, "https://gateway.marvel.com/v1/public/comics")
+    .with(
+      query: hash_including(query_params),
+    )
+    .to_return(
+      status: status_code,
+      body: JSON.generate(body_response),
+      headers: {}
+    )
+end
+
+def json_response_body
+  JSON.parse(response.body)["body"]
+end

--- a/street-comics-api/spec/spec_helper.rb
+++ b/street-comics-api/spec/spec_helper.rb
@@ -11,7 +11,10 @@
 # a separate helper file that requires the additional dependencies and performs
 # the additional setup, and require it from the spec files that actually need
 # it.
-#
+
+require 'webmock/rspec'
+WebMock.disable_net_connect!(allow_localhost: true)
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
WIP, but already retrieves data with success from the marvel API

Plays with some ideas to decouple our own API from external APIs