### PR TITLE
chore: deploy to heroku using the container stack

### DIFF
--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: street-comics-api/Dockerfile.production

--- a/street-comics-api/Dockerfile.production
+++ b/street-comics-api/Dockerfile.production
@@ -1,0 +1,14 @@
+FROM ruby:2.7.2
+RUN gem install rails bundler
+
+ENV RAILS_ENV production
+ENV INSTALL_PATH /opt/app
+
+RUN mkdir -p $INSTALL_PATH
+WORKDIR $INSTALL_PATH
+
+COPY . .
+
+RUN bundle install
+
+CMD bundle exec puma -C config/puma.rb


### PR DESCRIPTION
## Heroku app setup

Assuming the Heroku CLI is installed and you are logged in, run:

```sh
heroku apps:create street-comics-api
heroku stack:set container --app street-comics-api
heroku config:set RAILS_MASTER_KEY=`cat street-comics-api/config/master.key` --app street-comics-api
```

Then go to the Heroku Web UI and set the `Deployment method` to `Github`.

So that, the app will be automatically deployed after a new push to the `main` branch and CI is successful.