### PR TITLE
chore: improve docker build

### DIFF
--- a/street-comics-api/.dockerignore
+++ b/street-comics-api/.dockerignore
@@ -1,0 +1,23 @@
+# Ignore the default SQLite database.
+/db/*.sqlite3
+/db/*.sqlite3-*
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# Ignore pidfiles, but keep the directory.
+/tmp/pids/*
+!/tmp/pids/
+!/tmp/pids/.keep
+
+# Ignore uploaded files in development.
+/storage/*
+!/storage/.keep
+.byebug_history
+
+# Ignore master key for decrypting credentials and more.
+/config/master.key
+

--- a/street-comics-api/.env.sample
+++ b/street-comics-api/.env.sample
@@ -1,1 +1,10 @@
 # Sample .env file
+
+# To make it effective, create a copy of this file,
+# and replace the variables with the proper values
+#
+# cp -a .env.sample .env
+
+# Required to run the app
+# See https://guides.rubyonrails.org/security.html#custom-credentials
+RAILS_MASTER_KEY=<TO_REPLACE>

--- a/street-comics-api/Dockerfile.production
+++ b/street-comics-api/Dockerfile.production
@@ -7,8 +7,10 @@ ENV INSTALL_PATH /opt/app
 RUN mkdir -p $INSTALL_PATH
 WORKDIR $INSTALL_PATH
 
-COPY . .
+COPY Gemfile Gemfile.lock .
 
 RUN bundle install
+
+COPY . .
 
 CMD bundle exec puma -C config/puma.rb


### PR DESCRIPTION
Small improvements to make the build faster and easy to reproduce a production-like environment locally.

To run a production-like environment locally:

```sh
cd street-comics-api
docker build -t street-comics-api-production -f Dockerfile.production .
docker run -e RAILS_MASTER_KEY=<TO_REPLACE> -e PORT=8000 -p 8000:8000 street-comics-api-production
```

These commands can be improved in the future by using `docker-compose`.