### PR TITLE
fix: permit only expected params

### DIFF
--- a/street-comics-api/app/controllers/api/v1/comics_controller.rb
+++ b/street-comics-api/app/controllers/api/v1/comics_controller.rb
@@ -8,7 +8,11 @@ module Api
           limit: 15,
         }
 
-        response = client.comics(params.with_defaults(default_params))
+        client_params = params
+                          .with_defaults(default_params)
+                          .permit(:offset, :limit)
+
+        response = client.comics(client_params)
 
         render json: response, status: 200
       end

--- a/street-comics-api/spec/requests/comics_get_spec.rb
+++ b/street-comics-api/spec/requests/comics_get_spec.rb
@@ -55,10 +55,20 @@ describe "Comics GET request" do
 
     expect(json_response_body).to eq(stub_message)
   end
+
+  it 'only forwards permitted params to the marvel API' do
+    stub_comics_get
+      .with(query: hash_excluding({ "provider": "marvel", "other": "value" }))
+      .to_return(status: 200)
+
+    get '/api/v1/comics?provider=marvel&other=value'
+
+    expect(response.status).to eq(200)
+  end
 end
 
 def stub_comics_get_with(query_params: {}, status_code: 200, body_response: nil)
-  stub_request(:get, "https://gateway.marvel.com/v1/public/comics")
+  stub_comics_get
     .with(
       query: hash_including(query_params),
     )
@@ -67,6 +77,10 @@ def stub_comics_get_with(query_params: {}, status_code: 200, body_response: nil)
       body: JSON.generate(body_response),
       headers: {}
     )
+end
+
+def stub_comics_get
+  stub_request(:get, "https://gateway.marvel.com/v1/public/comics")
 end
 
 def json_response_body


### PR DESCRIPTION
So that we don't forward other params to the Marvel API

In the future, the `Adapters::Marvel::RequestAdapter` class could potentially take care of that.

But for now, let's keep it simple.

---

On another note, this controller is becoming too messy, but I need to focus on the front end now, so I will leave it as it is.

At least there are tests o/