### PR TITLE
fix(Docker): copy destination must end with a slash

### DIFF
--- a/street-comics-api/Dockerfile.production
+++ b/street-comics-api/Dockerfile.production
@@ -7,7 +7,7 @@ ENV INSTALL_PATH /opt/app
 RUN mkdir -p $INSTALL_PATH
 WORKDIR $INSTALL_PATH
 
-COPY Gemfile Gemfile.lock .
+COPY Gemfile Gemfile.lock ./
 
 RUN bundle install
 


### PR DESCRIPTION
Follows Docker docs:

If multiple <src> resources are specified, either directly or due to the use of a wildcard, then <dest> must be a directory, and it must end with a slash `/`

https://docs.docker.com/engine/reference/builder/#copy