### PR TITLE
chore: proxies API requests to the api app for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,18 @@ services:
     env_file:
       - ./street-comics-api/.env
 
+  street-comics-frontend:
+    image: node:14.17.4
+    command: npm run start
+    working_dir: /opt/app
+    volumes:
+      - ./street-comics-frontend:/opt/app
+      - street-comics-frontend-node_modules:/opt/app/node_modules
+    links:
+      - street-comics-api
+    ports:
+      - "4000:3000"
+
 volumes:
   street-comics-api-bundle_path:
+  street-comics-frontend-node_modules:

--- a/street-comics-api/config/environments/development.rb
+++ b/street-comics-api/config/environments/development.rb
@@ -63,4 +63,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.hosts << 'street-comics-api'
 end

--- a/street-comics-frontend/package.json
+++ b/street-comics-frontend/package.json
@@ -2,6 +2,7 @@
   "name": "app",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://street-comics-api:3000",
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",


### PR DESCRIPTION
For production, a similar approach can be used

For more details see https://create-react-app.dev/docs/proxying-api-requests-in-development/