### PR TITLE
feat: order comics by releaseDate:desc

### DIFF
--- a/street-comics-api/app/api/comics_api/v1/adapters/marvel/comics_request_adapter.rb
+++ b/street-comics-api/app/api/comics_api/v1/adapters/marvel/comics_request_adapter.rb
@@ -1,0 +1,68 @@
+module ComicsApi
+  module V1
+    module Adapters
+      module Marvel
+        class ComicsRequestAdapter
+
+          attr_reader(:params)
+
+          def self.create(params)
+            new(params).create
+          end
+
+          def initialize(params)
+            @params = params
+          end
+
+          def create
+            Models::ComicsParams.new(
+              limit: create_limit,
+              offset: create_offset,
+              order_by: create_order_by,
+            ).to_hash
+          end
+
+          private
+
+          def create_limit
+            params.fetch(:limit)
+          end
+
+          def create_offset
+            params.fetch(:offset)
+          end
+
+          def create_order_by
+            "#{order_by_direction}#{order_by_field}"
+          end
+
+          def order_by_field
+            order_by_field = params.fetch(:order_by_field)
+
+            order_by_field_map.fetch(order_by_field.to_sym)
+          end
+
+          def order_by_direction
+            order_by_direction = params.fetch(:order_by_direction)
+
+            order_by_direction_map.fetch(order_by_direction.to_sym)
+          end
+
+          def order_by_field_map
+            {
+              title: "title",
+              releaseDate: "onsaleDate"
+            }
+          end
+
+          def order_by_direction_map
+            {
+              asc: "",
+              desc: "-"
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/street-comics-api/app/api/comics_api/v1/adapters/marvel/comics_response_adapter.rb
+++ b/street-comics-api/app/api/comics_api/v1/adapters/marvel/comics_response_adapter.rb
@@ -15,22 +15,22 @@ module ComicsApi
           end
 
           def create
-            Models::ComicsResponse.new(body: create_comics_data)
+            ComicsApi::V1::Models::ComicsResponse.new(body: create_comics_data)
           end
 
           private
 
           def create_comics_data
-            Models::ComicsData.new(data: create_comics_list)
+            ComicsApi::V1::Models::ComicsData.new(data: create_comics_list)
           end
 
           def create_comics_list
-            Models::ComicsList.new(items: create_comics_items)
+            ComicsApi::V1::Models::ComicsList.new(items: create_comics_items)
           end
 
           def create_comics_items
             results.map do |item|
-              Models::ComicsItem.new(id: item[:id], title: item[:title])
+              ComicsApi::V1::Models::ComicsItem.new(id: item[:id], title: item[:title])
             end
           end
 

--- a/street-comics-api/app/api/comics_api/v1/adapters/marvel/models/comics_params.rb
+++ b/street-comics-api/app/api/comics_api/v1/adapters/marvel/models/comics_params.rb
@@ -1,0 +1,32 @@
+module ComicsApi
+  module V1
+    module Adapters
+      module Marvel
+        module Models
+
+          class ComicsParams
+
+            attr_reader(:limit)
+            attr_reader(:offset)
+            attr_reader(:order_by)
+
+            def initialize(params)
+              @limit = params.fetch(:limit)
+              @offset = params.fetch(:offset)
+              @order_by = params.fetch(:order_by)
+            end
+
+            def to_hash
+              {
+                limit: limit,
+                offset: offset,
+                orderBy: order_by
+              }
+            end
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/street-comics-api/app/api/comics_api/v1/adapters/marvel/request_adapter.rb
+++ b/street-comics-api/app/api/comics_api/v1/adapters/marvel/request_adapter.rb
@@ -7,7 +7,7 @@ module ComicsApi
           def initialize(args = nil) end
 
           def comics(params)
-            params
+            ComicsRequestAdapter.new(params).create
           end
         end
       end

--- a/street-comics-api/app/controllers/api/v1/comics_controller.rb
+++ b/street-comics-api/app/controllers/api/v1/comics_controller.rb
@@ -6,11 +6,13 @@ module Api
         default_params = {
           offset: 0,
           limit: 15,
+          order_by_field: 'releaseDate',
+          order_by_direction: 'desc'
         }
 
         client_params = params
                           .with_defaults(default_params)
-                          .permit(:offset, :limit)
+                          .permit(:offset, :limit, :order_by_field, :order_by_direction)
 
         response = client.comics(client_params)
 

--- a/street-comics-api/spec/api/comics_api/v1/adapters/marvel/comics_request_adapter_spec.rb
+++ b/street-comics-api/spec/api/comics_api/v1/adapters/marvel/comics_request_adapter_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe 'ComicsApi::V1::Adapters::Marvel::ComicsRequestAdapter' do
+
+  subject { ComicsApi::V1::Adapters::Marvel::ComicsRequestAdapter }
+
+  it 'should adapt releaseDate:asc' do
+    input_params = { offset: 0, limit: 1, order_by_field: 'releaseDate', order_by_direction: 'asc' }
+
+    output_params = subject.create(input_params)
+
+    expect(output_params).to eq({ offset: 0, limit: 1, orderBy: 'onsaleDate' })
+  end
+
+  it 'should adapt releaseDate:desc' do
+    input_params = { offset: 0, limit: 1, order_by_field: 'releaseDate', order_by_direction: 'desc' }
+
+    output_params = subject.create(input_params)
+
+    expect(output_params).to eq({ offset: 0, limit: 1, orderBy: '-onsaleDate' })
+  end
+
+  it 'should adapt title:asc' do
+    input_params = { offset: 0, limit: 1, order_by_field: 'title', order_by_direction: 'asc' }
+
+    output_params = subject.create(input_params)
+
+    expect(output_params).to eq({ offset: 0, limit: 1, orderBy: 'title' })
+  end
+
+  it 'should adapt title:desc' do
+    input_params = { offset: 0, limit: 1, order_by_field: 'title', order_by_direction: 'desc' }
+
+    output_params = subject.create(input_params)
+
+    expect(output_params).to eq({ offset: 0, limit: 1, orderBy: '-title' })
+  end
+end

--- a/street-comics-api/spec/requests/comics_get_spec.rb
+++ b/street-comics-api/spec/requests/comics_get_spec.rb
@@ -43,6 +43,28 @@ describe "Comics GET request" do
     expect(response.status).to eq(200)
   end
 
+  it 'accepts order_by_field and order_by_direction via query params' do
+    stub_comics_get_with(
+      {
+        query_params: { "orderBy": "title" },
+      })
+
+    get '/api/v1/comics?provider=marvel&order_by_field=title&order_by_direction=asc'
+
+    expect(response.status).to eq(200)
+  end
+
+  it 'has a default order_by_field and order_by_direction' do
+    stub_comics_get_with(
+      {
+        query_params: { "orderBy": "-onsaleDate" },
+      })
+
+    get '/api/v1/comics?provider=marvel'
+
+    expect(response.status).to eq(200)
+  end
+
   it 'adapts the marvel response to the comics response when body has results' do
     stub_comics_get_with(
       {

--- a/street-comics-frontend/src/api/comicsApi.ts
+++ b/street-comics-frontend/src/api/comicsApi.ts
@@ -3,7 +3,13 @@ import { useQuery } from 'react-query';
 import { ComicsApiParams, ComicsListApiData } from '../types';
 
 export const useComicsApi = (
-  params: ComicsApiParams = { provider: 'marvel' }
+  params: ComicsApiParams = {
+    provider: 'marvel',
+    offset: 0,
+    limit: 15,
+    order_by_field: 'releaseDate',
+    order_by_direction: 'desc',
+  }
 ) => {
   const endpoint = '/api/v1/comics';
 

--- a/street-comics-frontend/src/types/index.ts
+++ b/street-comics-frontend/src/types/index.ts
@@ -10,9 +10,16 @@ export type ComicsListApiData = {
 
 export type ComicsApiParams = {
   provider: ComicsProvider;
+  offset: number;
+  limit: number;
+  order_by_field: ComicsOrderByField;
+  order_by_direction: ComicsOrderByDirection;
 };
 
 export type ComicsProvider = 'marvel';
+
+export type ComicsOrderByField = 'releaseDate' | 'title';
+export type ComicsOrderByDirection = 'asc' | 'desc';
 
 export type ComicItem = {
   id: number;


### PR DESCRIPTION
`releaseDate:desc` is mapped to `-onsaleDate` on Marvel's API

Closes #6 