### PR TITLE
feat(API): add API to retrieve a list of characters

### DIFF
--- a/street-comics-api/app/api/comics_api/v1/adapters/marvel/characters_request_adapter.rb
+++ b/street-comics-api/app/api/comics_api/v1/adapters/marvel/characters_request_adapter.rb
@@ -1,0 +1,67 @@
+module ComicsApi
+  module V1
+    module Adapters
+      module Marvel
+        class CharactersRequestAdapter
+
+          attr_reader(:params)
+
+          def self.create(params)
+            new(params).create
+          end
+
+          def initialize(params)
+            @params = params
+          end
+
+          def create
+            Models::CharactersParams.new(
+              limit: create_limit,
+              offset: create_offset,
+              order_by: create_order_by,
+            ).to_hash
+          end
+
+          private
+
+          def create_limit
+            params.fetch(:limit)
+          end
+
+          def create_offset
+            params.fetch(:offset)
+          end
+
+          def create_order_by
+            "#{order_by_direction}#{order_by_field}"
+          end
+
+          def order_by_field
+            order_by_field = params.fetch(:order_by_field)
+
+            order_by_field_map.fetch(order_by_field.to_sym)
+          end
+
+          def order_by_direction
+            order_by_direction = params.fetch(:order_by_direction)
+
+            order_by_direction_map.fetch(order_by_direction.to_sym)
+          end
+
+          def order_by_field_map
+            {
+              name: "name",
+            }
+          end
+
+          def order_by_direction_map
+            {
+              asc: "",
+              desc: "-"
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/street-comics-api/app/api/comics_api/v1/adapters/marvel/characters_response_adapter.rb
+++ b/street-comics-api/app/api/comics_api/v1/adapters/marvel/characters_response_adapter.rb
@@ -1,0 +1,59 @@
+module ComicsApi
+  module V1
+    module Adapters
+      module Marvel
+        class CharactersResponseAdapter
+
+          attr_reader(:response)
+
+          def self.create(response)
+            new(response).create
+          end
+
+          def initialize(response)
+            @response = response
+          end
+
+          def create
+            ComicsApi::V1::Models::CharactersResponse.new(body: create_characters_data)
+          end
+
+          private
+
+          def create_characters_data
+            ComicsApi::V1::Models::CharactersData.new(data: create_characters_list)
+          end
+
+          def create_characters_list
+            ComicsApi::V1::Models::CharactersList.new(items: create_characters_items)
+          end
+
+          def create_characters_items
+            results.map do |item|
+              ComicsApi::V1::Models::CharactersItem.new(
+                id: item[:id],
+                name: item[:name],
+              )
+            end
+          end
+
+          def results
+            return [] if empty?
+
+            response_body[:data][:results]
+          end
+
+          def empty?
+            response_body.nil? || response_body[:data].nil? || response_body[:data][:results].nil?
+          end
+
+          def response_body
+            return if @response.body.nil?
+
+            @response.body.with_indifferent_access
+          end
+        end
+      end
+    end
+  end
+end

--- a/street-comics-api/app/api/comics_api/v1/adapters/marvel/models/characters_params.rb
+++ b/street-comics-api/app/api/comics_api/v1/adapters/marvel/models/characters_params.rb
@@ -1,0 +1,32 @@
+module ComicsApi
+  module V1
+    module Adapters
+      module Marvel
+        module Models
+
+          class CharactersParams
+
+            attr_reader(:limit)
+            attr_reader(:offset)
+            attr_reader(:order_by)
+
+            def initialize(params)
+              @limit = params.fetch(:limit)
+              @offset = params.fetch(:offset)
+              @order_by = params.fetch(:order_by)
+            end
+
+            def to_hash
+              {
+                limit: limit,
+                offset: offset,
+                orderBy: order_by
+              }
+            end
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/street-comics-api/app/api/comics_api/v1/adapters/marvel/request_adapter.rb
+++ b/street-comics-api/app/api/comics_api/v1/adapters/marvel/request_adapter.rb
@@ -9,6 +9,10 @@ module ComicsApi
           def comics(params)
             ComicsRequestAdapter.new(params).create
           end
+
+          def characters(params)
+            CharactersRequestAdapter.new(params).create
+          end
         end
       end
     end

--- a/street-comics-api/app/api/comics_api/v1/adapters/marvel/response_adapter.rb
+++ b/street-comics-api/app/api/comics_api/v1/adapters/marvel/response_adapter.rb
@@ -9,6 +9,10 @@ module ComicsApi
           def comics(response)
             ComicsResponseAdapter.new(response).create
           end
+
+          def characters(response)
+            CharactersResponseAdapter.new(response).create
+          end
         end
       end
     end

--- a/street-comics-api/app/api/comics_api/v1/client.rb
+++ b/street-comics-api/app/api/comics_api/v1/client.rb
@@ -18,6 +18,12 @@ module ComicsApi
         response_adapter.comics(response)
       end
 
+      def characters(params)
+        client_params = request_adapter.characters(params)
+        response = client.characters(client_params)
+        response_adapter.characters(response)
+      end
+
       private
 
       def find_client(provider)

--- a/street-comics-api/app/api/comics_api/v1/models/characters_data.rb
+++ b/street-comics-api/app/api/comics_api/v1/models/characters_data.rb
@@ -1,0 +1,15 @@
+module ComicsApi
+  module V1
+    module Models
+      class CharactersData
+
+        attr_reader(:data)
+
+        def initialize(params)
+          @data = params.fetch(:data)
+        end
+      end
+
+    end
+  end
+end

--- a/street-comics-api/app/api/comics_api/v1/models/characters_item.rb
+++ b/street-comics-api/app/api/comics_api/v1/models/characters_item.rb
@@ -1,0 +1,17 @@
+module ComicsApi
+  module V1
+    module Models
+      class CharactersItem
+
+        attr_reader(:id)
+        attr_reader(:name)
+
+        def initialize(params)
+          @id = params.fetch(:id)
+          @name = params.fetch(:name)
+        end
+      end
+
+    end
+  end
+end

--- a/street-comics-api/app/api/comics_api/v1/models/characters_list.rb
+++ b/street-comics-api/app/api/comics_api/v1/models/characters_list.rb
@@ -1,0 +1,15 @@
+module ComicsApi
+  module V1
+    module Models
+      class CharactersList
+
+        attr_reader(:items)
+
+        def initialize(params)
+          @items = params.fetch(:items)
+        end
+      end
+
+    end
+  end
+end

--- a/street-comics-api/app/api/comics_api/v1/models/characters_response.rb
+++ b/street-comics-api/app/api/comics_api/v1/models/characters_response.rb
@@ -1,0 +1,15 @@
+module ComicsApi
+  module V1
+    module Models
+      class CharactersResponse
+
+        attr_reader(:body)
+
+        def initialize(params)
+          @body = params.fetch(:body)
+        end
+      end
+
+    end
+  end
+end

--- a/street-comics-api/app/api/marvel_api/v1/client.rb
+++ b/street-comics-api/app/api/marvel_api/v1/client.rb
@@ -8,6 +8,10 @@ module MarvelApi
         client.get('comics', params)
       end
 
+      def characters(params)
+        client.get('characters', params)
+      end
+
       private
 
       def client

--- a/street-comics-api/app/controllers/api/v1/characters_controller.rb
+++ b/street-comics-api/app/controllers/api/v1/characters_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  module V1
+    class CharactersController < ApplicationController
+
+      def index
+        default_params = {
+          offset: 0,
+          limit: 15,
+          order_by_field: 'name',
+          order_by_direction: 'asc'
+        }
+
+        client_params = params
+                          .with_defaults(default_params)
+                          .permit(:offset, :limit, :order_by_field, :order_by_direction)
+
+        response = client.characters(client_params)
+
+        render json: response.body, status: 200
+      end
+
+      private
+
+      def client
+        provider = params.fetch(:provider)
+        ComicsApi::V1::Client.new(provider)
+      end
+    end
+
+  end
+end

--- a/street-comics-api/config/routes.rb
+++ b/street-comics-api/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/comics', to: 'comics#index'
+      get '/characters', to: 'characters#index'
     end
   end
 end

--- a/street-comics-api/spec/api/comics_api/v1/adapters/marvel/characters_request_adapter_spec.rb
+++ b/street-comics-api/spec/api/comics_api/v1/adapters/marvel/characters_request_adapter_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'ComicsApi::V1::Adapters::Marvel::CharactersRequestAdapter' do
+
+  subject { ComicsApi::V1::Adapters::Marvel::CharactersRequestAdapter }
+
+  it 'should adapt name:asc' do
+    input_params = { offset: 0, limit: 1, order_by_field: 'name', order_by_direction: 'asc' }
+
+    output_params = subject.create(input_params)
+
+    expect(output_params).to eq({ offset: 0, limit: 1, orderBy: 'name' })
+  end
+
+  it 'should adapt name:desc' do
+    input_params = { offset: 0, limit: 1, order_by_field: 'name', order_by_direction: 'desc' }
+
+    output_params = subject.create(input_params)
+
+    expect(output_params).to eq({ offset: 0, limit: 1, orderBy: '-name' })
+  end
+end

--- a/street-comics-api/spec/api/comics_api/v1/adapters/marvel/characters_response_adapter_spec.rb
+++ b/street-comics-api/spec/api/comics_api/v1/adapters/marvel/characters_response_adapter_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe 'ComicsApi::V1::Adapters::Marvel::CharactersResponseAdapter' do
+
+  subject { ComicsApi::V1::Adapters::Marvel::CharactersResponseAdapter }
+
+  it 'should have no items when response is empty' do
+    input_response = double(:response, body: nil)
+
+    output_response = subject.create(input_response)
+
+    expect(output_response.body.data.items).to eq([])
+  end
+
+  it 'should have no items when body is empty' do
+    input_response = double(:response, body: {})
+
+    output_response = subject.create(input_response)
+
+    expect(output_response.body.data.items).to eq([])
+  end
+
+  it 'should have no items when data is empty' do
+    input_response = double(:response, body: { data: {} })
+
+    output_response = subject.create(input_response)
+
+    expect(output_response.body.data.items).to eq([])
+  end
+
+  it 'should have no items when results is empty' do
+    input_response = double(:response, body: { data: { results: [] } })
+
+    output_response = subject.create(input_response)
+
+    expect(output_response.body.data.items).to eq([])
+  end
+
+  it 'should have one item when there is a result' do
+    item = {
+      id: 1,
+      name: "Character name",
+    }
+    input_response = double(:response, body: { data: { results: [item] } })
+
+    output_response = subject.create(input_response)
+
+    expect(output_response.body.data.items.size).to eq(1)
+    item0 = output_response.body.data.items[0]
+    expect(item0.id).to eq(1)
+    expect(item0.name).to eq("Character name")
+  end
+end

--- a/street-comics-api/spec/requests/characters_get_spec.rb
+++ b/street-comics-api/spec/requests/characters_get_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+describe "Characters GET request" do
+
+  before do
+    stub_credentials = {
+      v1: {
+        public_api_key: 'public_api_key',
+        private_api_key: 'private_api_key',
+      }
+    }
+
+    allow(Rails.application.credentials).to receive(:marvel_api).and_return(stub_credentials)
+  end
+
+  it 'accepts "marvel" as a provider' do
+    stub_characters_get_with
+
+    get '/api/v1/characters?provider=marvel'
+
+    expect(response.status).to eq(200)
+  end
+
+  it 'accepts an offset and limit via query params' do
+    stub_characters_get_with(
+      {
+        query_params: { "offset": "15", "limit": "30" },
+      })
+
+    get '/api/v1/characters?provider=marvel&offset=15&limit=30'
+
+    expect(response.status).to eq(200)
+  end
+
+  it 'has a default offset and limit' do
+    stub_characters_get_with(
+      {
+        query_params: { "offset": "0", "limit": "15" },
+      })
+
+    get '/api/v1/characters?provider=marvel'
+
+    expect(response.status).to eq(200)
+  end
+
+  it 'accepts order_by_field and order_by_direction via query params' do
+    stub_characters_get_with(
+      {
+        query_params: { "orderBy": "name" },
+      })
+
+    get '/api/v1/characters?provider=marvel&order_by_field=name&order_by_direction=asc'
+
+    expect(response.status).to eq(200)
+  end
+
+  it 'has a default order_by_field and order_by_direction' do
+    stub_characters_get_with(
+      {
+        query_params: { "orderBy": "name" },
+      })
+
+    get '/api/v1/characters?provider=marvel'
+
+    expect(response.status).to eq(200)
+  end
+
+  it 'adapts the marvel response to the comics response when body has results' do
+    item_mock = {
+      id: 1,
+      name: "Sample Name",
+    }
+    stub_characters_get_with(
+      {
+        body_response: { data: { results: [item_mock] } }
+      })
+
+    get '/api/v1/characters?provider=marvel'
+
+    expected_item = {
+      id: 1,
+      name: "Sample Name",
+    }
+
+    expect(response.body).to eq({ data: { items: [expected_item] } }.to_json)
+  end
+
+  it 'adapts the marvel response to the comics response when body is empty' do
+    stub_characters_get_with(
+      {
+        body_response: nil
+      })
+
+    get '/api/v1/characters?provider=marvel'
+
+    expect(response.body).to eq({ data: { items: [] } }.to_json)
+  end
+
+  it 'only forwards permitted params to the marvel API' do
+    stub_characters_get
+      .with(query: hash_excluding({ "provider": "marvel", "other": "value" }))
+      .to_return(status: 200)
+
+    get '/api/v1/characters?provider=marvel&other=value'
+
+    expect(response.status).to eq(200)
+  end
+end
+
+def stub_characters_get_with(query_params: {}, status_code: 200, body_response: nil)
+  stub_characters_get
+    .with(
+      query: hash_including(query_params),
+    )
+    .to_return(
+      status: status_code,
+      body: JSON.generate(body_response),
+      headers: {}
+    )
+end
+
+def stub_characters_get
+  stub_request(:get, "https://gateway.marvel.com/v1/public/characters")
+end


### PR DESCRIPTION
So that API users can find out characters and their ids, and later on filter comics of specific characters.

It's clear that there is some code duplication between the `/comics` and `/characters` endpoints, but let's wait for more requirements and endpoints to come, so that the abstractions and code reuse opportunities will be more clear.