### PR TITLE
chore(config): change react-query defaults

### DIFF
--- a/street-comics-frontend/src/App.tsx
+++ b/street-comics-frontend/src/App.tsx
@@ -3,7 +3,15 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import ComicsPage from './pages/comics/ComicsPage';
 
 const App = () => {
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+      },
+    },
+  });
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
The app data doesn't change often, so there is no benefit on refetch on windowFocus or reconnect